### PR TITLE
Fix fetching commits from API

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -742,7 +742,6 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 name = "cultivation"
 version = "0.1.0"
 dependencies = [
- "base64",
  "duct",
  "futures-util",
  "http",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,7 +37,6 @@ duct = "0.13.5"
 
 # Serialization.
 serde_json = "1"
-base64 = "0.13.0"
 
 # System process elevation.
 is_elevated = "0.1.2"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -42,7 +42,6 @@ fn main() {
       disconnect,
       req_get,
       get_bg_file,
-      base64_decode,
       is_game_running,
       get_theme_list,
       system_helpers::run_command,
@@ -232,10 +231,4 @@ async fn get_bg_file(bg_path: String, appdata: String) -> String {
       "".to_string()
     }
   };
-}
-
-#[tauri::command]
-fn base64_decode(encoded: String) -> String {
-  let decoded = base64::decode(&encoded).unwrap();
-  return String::from_utf8(decoded).unwrap();
 }

--- a/src/ui/components/news/NewsSection.tsx
+++ b/src/ui/components/news/NewsSection.tsx
@@ -56,9 +56,7 @@ export default class NewsSection extends React.Component<IProps, IState> {
         const commits: string = await invoke('req_get', { url: 'https://api.github.com/repos/Grasscutters/Grasscutter/commits' })
         obj = JSON.parse(commits)
       } else {
-        const decoded: string = await invoke('base64_decode', { encoded: obj.commits })
-        const commitData = JSON.parse(decoded)
-        obj = commitData.gc_stable
+        obj = obj.commits.gc_stable
       }
 
       // Probably rate-limited


### PR DESCRIPTION
Recent commits are now displayed. Not sure why the Base64 code was here, maybe @KingRainbow44 can clarify.