### PR TITLE
Fix patched metadata checking

### DIFF
--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -72,7 +72,7 @@ export async function patchGame() {
 
   // Do we have a patch already?
   const patchedExists = await invoke('dir_exists', {
-    path: await getGameMetadataPath() + '\\global-metadata-patched.dat'
+    path: await getBackupMetadataPath() + '\\global-metadata-patched.dat'
   })
 
   if (!patchedExists) {


### PR DESCRIPTION
Issue: The function checked the wrong directory for global-metadata-patched.dat