### PR TITLE
Disable CSP errors while loading js files from themes

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -53,7 +53,7 @@
       }
     },
     "security": {
-      "csp": "default-src 'self' https://asset.localhost; img-src 'self'; img-src https://* asset: https://asset.localhost"
+      "csp": "default-src 'self' https://asset.localhost/; img-src 'self'; img-src https://* asset: https://asset.localhost/; media-src https://* asset: https://asset.localhost/; script-src 'self' https://asset.localhost/"
     },
     "updater": {
       "active": false,


### PR DESCRIPTION
Disables CSP errors while loading themes js files
Before: 
![image](https://user-images.githubusercontent.com/40639199/182250439-7ba52162-7264-4c7f-b363-33cdc1f150a9.png)

After:
![image](https://user-images.githubusercontent.com/40639199/182250467-b8b756ff-cea1-42c1-8726-ff0451d0484e.png)
