### PR TITLE
Fix downloads' "visual bug". Aka files showing `extracting` even after being extracted

### DIFF
--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -75,6 +75,7 @@ export default class DownloadHandler {
       this.downloads[index].error = errorData.error
     })
 
+    // Extraction events
     listen('extract_start', ({ payload }) => {
       // Find the download that is extracting and set it's status as such
       const index = this.downloads.findIndex((download) => download.path === payload)

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -75,16 +75,15 @@ export default class DownloadHandler {
       this.downloads[index].error = errorData.error
     })
 
-    // Extraction events
     listen('extract_start', ({ payload }) => {
-      // Find the download that is no extracting and set it's status as such
+      // Find the download that is extracting and set it's status as such
       const index = this.downloads.findIndex((download) => download.path === payload)
       this.downloads[index].status = 'extracting'
     })
 
-    listen('extract_end', ({ payload }) => {
-      // Find the download that is no extracting and set it's status as such
-      const index = this.downloads.findIndex((download) => download.path === payload)
+    listen('extract_end', ({ payload }:any) => {
+      // Find the download that is not extracting and set it's status as such
+      const index = this.downloads.findIndex((download) => download.path === (payload.file ? payload.file : payload.folder) || null)
       this.downloads[index].status = 'finished'
     })
   }


### PR DESCRIPTION
it didnt work before cuz `zipfile` in the backend was a `string` and the `payload` that `unzip.rs` returned was an `object`.
works perfectly fine now.

**This was the visual bug**
<img src="https://cdn.discordapp.com/attachments/1012376328105902204/1012376577461461033/unknown.png" width=80%>

**Logging the values before:**
<img src="https://cdn.discordapp.com/attachments/981291804202778664/1012483547535261807/unknown.png" width=80%>
You can see the `extract_end` event was not logged.

**After:**
<img src="https://cdn.discordapp.com/attachments/981291804202778664/1012520401202589726/unknown.png" width=80%>
It perfectly logged.