### PR TITLE
use system certificates instead of Mozilla certificates

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,7 +46,7 @@ serde_json = "1"
 
 # Dependencies for the HTTP(S) proxy.
 http = "0.2"
-hudsucker = "0.17.2"
+hudsucker = { version = "0.17.2", features = ["native-tls-client"] }
 tracing = "0.1.21"
 tokio-rustls = "0.23.0"
 tokio-tungstenite = "0.17.0"

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -125,7 +125,7 @@ pub async fn create_proxy(proxy_port: u16, certificate_path: String) {
   // Create an instance of the proxy.
   let proxy = ProxyBuilder::new()
     .with_addr(SocketAddr::from(([0, 0, 0, 0], proxy_port)))
-    .with_rustls_client()
+    .with_native_tls_client()
     .with_ca(authority)
     .with_http_handler(ProxyHandler)
     .build();


### PR DESCRIPTION
The original implementation uses `rustls-client`, and `rusttls` uses `webpki-roots`, a rather static set of certificates from Mozilla, for certificate verification. Therefore, a user cannot use their own CA certificates.
This problem can be resolved if we simply use native tls client, which will use the certificates stored on OS.