### PR TITLE
Fix 3dmigoto Path Setting

### DIFF
--- a/src-tauri/src/system_helpers.rs
+++ b/src-tauri/src/system_helpers.rs
@@ -115,7 +115,7 @@ pub fn set_migoto_target(path: String, migoto_path: String) -> bool {
   // Set options
   conf
     .with_section(Some("Loader"))
-    .set("target", pathbuf.file_name().unwrap().to_str().unwrap());
+    .set("target", "GenshinImpact.exe");
 
   // Write file
   match conf.write_to_file(&migoto_pathbuf) {


### PR DESCRIPTION
Fixes the issue of 3dmigoto path being set incorrectly, which was preventing 3dmigoto from loading unless the user manually edited d3dx.ini.

Fixes #133 