### PR TITLE
Refactor path concatenation and make error handling src-tauri/src/lang.rs

### DIFF
--- a/src-tauri/src/lang.rs
+++ b/src-tauri/src/lang.rs
@@ -1,5 +1,5 @@
 use crate::system_helpers::*;
-use std::path::{Path, PathBuf};
+use std::path::{ Path, PathBuf };
 
 #[tauri::command]
 pub async fn get_lang(window: tauri::Window, lang: String) -> String {
@@ -27,7 +27,12 @@ pub async fn get_languages() -> std::collections::HashMap<String, String> {
   for entry in lang_files {
     let entry = entry.unwrap();
     let path = entry.path();
-    let filename = path.file_name().unwrap().to_str().unwrap();
+    let filename = path
+      .file_name()
+      .unwrap_or_else(|| panic!("Failed to get filename from path: {:?}", path))
+      .to_str()
+      .unwrap_or_else(|| panic!("Failed to convert filename to string: {:?}", path))
+      .to_string();
 
     let content = match std::fs::read_to_string(&path) {
       Ok(x) => x,

--- a/src-tauri/src/lang.rs
+++ b/src-tauri/src/lang.rs
@@ -6,9 +6,8 @@ pub async fn get_lang(window: tauri::Window, lang: String) -> String {
   let lang = lang.to_lowercase();
 
   // Send contents of language file back
-  let lang_path: PathBuf = [&install_location(), "lang", &format!("{}.json", lang)]
-    .iter()
-    .collect();
+  let lang_path = install_location().join("lang").join(format!("{}.json", lang));
+
   match std::fs::read_to_string(lang_path) {
     Ok(x) => x,
     Err(e) => {

--- a/src-tauri/src/lang.rs
+++ b/src-tauri/src/lang.rs
@@ -6,8 +6,9 @@ pub async fn get_lang(window: tauri::Window, lang: String) -> String {
   let lang = lang.to_lowercase();
 
   // Send contents of language file back
-  let lang_path = install_location().join("lang").join(format!("{}.json", lang));
-
+  let lang_path: PathBuf = [&install_location(), "lang", &format!("{}.json", lang)]
+    .iter()
+    .collect();
   match std::fs::read_to_string(lang_path) {
     Ok(x) => x,
     Err(e) => {


### PR DESCRIPTION
I think we can use join() method on the PathBuf directly to concatenate the segments, this will make the code more short and easier to read.

And instead of using unwrap() on the file_name() and to_str() methods, we can use unwrap_or_else() to provide a default value or an error handler function, this should prevent panics.