### PR TITLE
Fix overlap on resize

### DIFF
--- a/src/ui/components/RightBar.css
+++ b/src/ui/components/RightBar.css
@@ -11,10 +11,7 @@
   width: 80px;
   right: 0%;
 
-  z-index: 99;
-
   background-color: rgba(77, 77, 77, 0.6);
-  z-index: 999;
 }
 
 .BarImg:hover {

--- a/src/ui/components/ServerLaunchSection.tsx
+++ b/src/ui/components/ServerLaunchSection.tsx
@@ -31,8 +31,6 @@ interface IState {
   ipPlaceholder: string
   portPlaceholder: string
 
-  portHelpText: string
-
   httpsLabel: string
   httpsEnabled: boolean
 
@@ -55,7 +53,6 @@ export default class ServerLaunchSection extends React.Component<IProps, IState>
       port: '',
       ipPlaceholder: '',
       portPlaceholder: '',
-      portHelpText: '',
       httpsLabel: '',
       httpsEnabled: false,
       launchServer: () => {
@@ -90,7 +87,6 @@ export default class ServerLaunchSection extends React.Component<IProps, IState>
       port: config.last_port || '',
       ipPlaceholder: await translate('main.ip_placeholder'),
       portPlaceholder: await translate('help.port_placeholder'),
-      portHelpText: await translate('help.port_help_text'),
       httpsLabel: await translate('main.https_enable'),
       httpsEnabled: config.https_enabled || false,
       swag: config.swag_mode || false,
@@ -294,7 +290,7 @@ export default class ServerLaunchSection extends React.Component<IProps, IState>
                 onChange={this.setPort}
                 initalValue={this.state.port}
               />
-              <HelpButton contents={this.state.portHelpText} />
+              <HelpButton contents={'help.port_help_text'} />
               <Checkbox
                 id="httpsEnable"
                 label={this.state.httpsLabel}


### PR DESCRIPTION
Makes right bar not stay always on top, which fixes it overlapping buttons when resizing horizontally.

Fixes #160 