### PR TITLE
Update more redirecting

### DIFF
--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -171,7 +171,26 @@ impl HttpHandler for ProxyHandler {
   async fn should_intercept(&mut self, _ctx: &HttpContext, _req: &Request<Body>) -> bool {
     let uri = _req.uri().to_string();
 
-    uri.contains("hoyoverse.com") || uri.contains("mihoyo.com") || uri.contains("yuanshen.com")
+    let more = get_config().redirect_more;
+
+    match more {
+      Some(true) => {
+        uri.contains("hoyoverse.com")
+          || uri.contains("mihoyo.com")
+          || uri.contains("yuanshen.com")
+          || uri.contains("starrails.com")
+          || uri.contains("bhsr.com")
+          || uri.contains("bh3.com")
+          || uri.contains("honkaiimpact3.com")
+          || uri.contains("zenlesszonezero.com")
+      }
+      Some(false) => {
+        uri.contains("hoyoverse.com") || uri.contains("mihoyo.com") || uri.contains("yuanshen.com")
+      }
+      None => {
+        uri.contains("hoyoverse.com") || uri.contains("mihoyo.com") || uri.contains("yuanshen.com")
+      }
+    }
   }
 }
 

--- a/src/ui/components/ServerLaunchSection.tsx
+++ b/src/ui/components/ServerLaunchSection.tsx
@@ -119,7 +119,11 @@ export default class ServerLaunchSection extends React.Component<IProps, IState>
 
     // Connect to proxy
     if (config.toggle_grasscutter) {
-      if (config.patch_rsa) {
+      const game_exe = await getGameExecutable()
+
+      const patchable = game_exe?.toLowerCase().includes('genshin' || 'yuanshen')
+
+      if (config.patch_rsa && patchable) {
         const gameVersion = await getGameVersion()
         console.log(gameVersion)
 
@@ -147,8 +151,6 @@ export default class ServerLaunchSection extends React.Component<IProps, IState>
           return
         }
       }
-
-      const game_exe = await getGameExecutable()
 
       // Save last connected server and port
       await setConfigOption('last_ip', this.state.ip)

--- a/src/ui/components/menu/Options.tsx
+++ b/src/ui/components/menu/Options.tsx
@@ -150,6 +150,11 @@ export default class Options extends React.Component<IProps, IState> {
       )
     }
 
+    // If setting any other game, automatically set to redirect more
+    if (!value.toLowerCase().includes('genshin' || 'yuanshen')) {
+      this.toggleOption('redirect_more')
+    }
+
     this.setState({
       game_install_path: value,
     })

--- a/src/ui/components/menu/Options.tsx
+++ b/src/ui/components/menu/Options.tsx
@@ -152,7 +152,9 @@ export default class Options extends React.Component<IProps, IState> {
 
     // If setting any other game, automatically set to redirect more
     if (!value.toLowerCase().includes('genshin' || 'yuanshen')) {
-      this.toggleOption('redirect_more')
+      if (!this.state.redirect_more) {
+        this.toggleOption('redirect_more')
+      }
     }
 
     this.setState({


### PR DESCRIPTION
- Adds more redirects to should_intercept so that all connections are correctly grabbed
- Skips patching on games that don't need it
- Automatically enables more redirects when setting any other certain anime games