### PR TITLE
Settings & QoL Alerts

### DIFF
--- a/src-tauri/lang/chs.json
+++ b/src-tauri/lang/chs.json
@@ -33,7 +33,9 @@
     "horny_mode": "Horny 模式",
     "auto_mongodb": "自动启动 MongoDB",
     "un_elevated": "非提升运行游戏（无管理员）",
-    "redirect_more": "还可以重定向其他MHY游戏"
+    "redirect_more": "还可以重定向其他MHY游戏",
+    "web_cache": "删除 webCaches 文件夹",
+    "launch_args": "Launch Args"
   },
   "downloads": {
     "grasscutter_fullbuild": "下载 Grasscutter 一体化",

--- a/src-tauri/lang/cht.json
+++ b/src-tauri/lang/cht.json
@@ -33,7 +33,9 @@
     "horny_mode": "Horny模式",
     "auto_mongodb": "自動啟動 MongoDB",
     "un_elevated": "在不升高的情况下运行游戏（没有管理员）。",
-    "redirect_more": "同時重定向其他 MHY 遊戲"
+    "redirect_more": "同時重定向其他 MHY 遊戲",
+    "web_cache": "刪除 webCaches 文件夾",
+    "launch_args": "Launch Args"
   },
   "downloads": {
     "grasscutter_fullbuild": "下載Grasscutter多合一下載",

--- a/src-tauri/lang/de.json
+++ b/src-tauri/lang/de.json
@@ -35,7 +35,9 @@
     "un_elevated": "Spiel ohne Administratorrechte ausführen",
     "redirect_more": "Auch andere miHoYo-Spiele umleiten",
     "check_aagl": "Für weitere Optionen, schaue weiter",
-    "grasscutter_elevation": "Methode zur Ausführung von GC auf eingeschränkten Ports"
+    "grasscutter_elevation": "Methode zur Ausführung von GC auf eingeschränkten Ports",
+    "web_cache": "WebCaches-Ordner löschen",
+    "launch_args": "Launch Args"
   },
   "downloads": {
     "grasscutter_fullbuild": "Grasscutter All-in-One herunterladen",

--- a/src-tauri/lang/en.json
+++ b/src-tauri/lang/en.json
@@ -36,7 +36,8 @@
     "redirect_more": "Also redirect other MHY games",
     "check_aagl": "For more options, check the other launcher",
     "grasscutter_elevation": "Method of running GC on restricted ports",
-    "web_cache": "Delete webCaches folder"
+    "web_cache": "Delete webCaches folder",
+    "launch_args": "Launch Args"
   },
   "downloads": {
     "grasscutter_fullbuild": "Download Grasscutter All-in-One",

--- a/src-tauri/lang/en.json
+++ b/src-tauri/lang/en.json
@@ -35,7 +35,8 @@
     "un_elevated": "Run the game non-elevated (no admin)",
     "redirect_more": "Also redirect other MHY games",
     "check_aagl": "For more options, check the other launcher",
-    "grasscutter_elevation": "Method of running GC on restricted ports"
+    "grasscutter_elevation": "Method of running GC on restricted ports",
+    "web_cache": "Delete webCaches folder"
   },
   "downloads": {
     "grasscutter_fullbuild": "Download Grasscutter All-in-One",

--- a/src-tauri/lang/es.json
+++ b/src-tauri/lang/es.json
@@ -33,7 +33,9 @@
     "horny_mode": "Modo cachondo",
     "auto_mongodb": "Iniciar automáticamente MongoDB",
     "un_elevated": "Ejecutar el juego sin permisos de administrador",
-    "redirect_more": "También redirigir otros juegos MHY"
+    "redirect_more": "También redirigir otros juegos MHY",
+    "web_cache": "Eliminar la carpeta webCaches",
+    "launch_args": "Launch Args"
   },
   "downloads": {
     "grasscutter_fullbuild": "Descargar datos todo en uno de Grasscutter",

--- a/src-tauri/lang/fr.json
+++ b/src-tauri/lang/fr.json
@@ -33,7 +33,9 @@
     "horny_mode": "Mode horny",
     "auto_mongodb": "Démarrer automatiquement MongoDB",
     "un_elevated": "Exécuter le jeu sans élévation (pas d'administrateur)",
-    "redirect_more": "Réorienter également les autres jeux MHY"
+    "redirect_more": "Réorienter également les autres jeux MHY",
+    "web_cache": "Supprimer le dossier webCaches",
+    "launch_args": "Launch Args"
   },
   "downloads": {
     "grasscutter_fullbuild": "Telecharger Grasscutter tout-en-un",

--- a/src-tauri/lang/id.json
+++ b/src-tauri/lang/id.json
@@ -32,7 +32,9 @@
     "horny_mode": "Mode Terangsang",
     "auto_mongodb": "Mulai MongoDB secara otomatis",
     "un_elevated": "Jalankan game yang tidak ditinggikan (tanpa admin)",
-    "redirect_more": "Juga mengarahkan ulang game MHY lainnya"
+    "redirect_more": "Juga mengarahkan ulang game MHY lainnya",
+    "web_cache": "Hapus folder webCaches",
+    "launch_args": "Launch Args"
   },
   "downloads": {
     "grasscutter_fullbuild": "Sedang Mendownload Grasscutter Semua Dalam Satu",

--- a/src-tauri/lang/it.json
+++ b/src-tauri/lang/it.json
@@ -33,7 +33,9 @@
     "horny_mode": "Modalità Horny",
     "auto_mongodb": "Avvia Automaticamente MongoDB",
     "un_elevated": "Avvia il gioco non-elevato (non admin)",
-    "redirect_more": "Reindirizza anche altri giochi MHY"
+    "redirect_more": "Reindirizza anche altri giochi MHY",
+    "web_cache": "Elimina la cartella webCaches",
+    "launch_args": "Launch Args"
   },
   "downloads": {
     "grasscutter_fullbuild": "Scarica Grasscutter Tutto-in-Uno",

--- a/src-tauri/lang/ko.json
+++ b/src-tauri/lang/ko.json
@@ -33,7 +33,9 @@
     "horny_mode": "Horny 모드",
     "auto_mongodb": "MongoDB 자동 시작",
     "un_elevated": "게임 비상승 실행(관리자 없음)",
-    "redirect_more": "다른 MHY 게임도 리디렉션"
+    "redirect_more": "다른 MHY 게임도 리디렉션",
+    "web_cache": "webCaches 폴더 삭제",
+    "launch_args": "Launch Args"
   },
   "downloads": {
     "grasscutter_fullbuild": "올인원 Grasscutter 다운로드",

--- a/src-tauri/lang/lv.json
+++ b/src-tauri/lang/lv.json
@@ -31,7 +31,9 @@
     "horny_mode": "Uzbudināts režīms",
     "auto_mongodb": "Automātiski startējiet MongoDB",
     "un_elevated": "Palaist spēli bez paaugstinājuma (bez administratora)",
-    "redirect_more": "Arī novirzīt citas MHY spēles"
+    "redirect_more": "Arī novirzīt citas MHY spēles",
+    "web_cache": "Dzēsiet mapi WebCaches",
+    "launch_args": "Launch Args"
   },
   "downloads": {
     "grasscutter_fullbuild": "Lejupielādējiet Grasscutter viss vienā",

--- a/src-tauri/lang/nl.json
+++ b/src-tauri/lang/nl.json
@@ -32,7 +32,9 @@
     "horny_mode": "Geile modus",
     "auto_mongodb": "Start automatisch MongoDB",
     "un_elevated": "Voer het spel uit zonder hoogtevrees (geen admin)",
-    "redirect_more": "Richt ook andere MHY-spellen"
+    "redirect_more": "Richt ook andere MHY-spellen",
+    "web_cache": "Verwijder de webCaches-map",
+    "launch_args": "Launch Args"
   },
   "downloads": {
     "grasscutter_fullbuild": "Grasscutter Alles-in-één Downloaden",

--- a/src-tauri/lang/pl.json
+++ b/src-tauri/lang/pl.json
@@ -35,7 +35,9 @@
     "un_elevated": "Uruchamiaj grę bez uprawnień administratora/roota",
     "redirect_more": "Przekieruj też inne gry MHY",
     "check_aagl": "Więcej opcji znajdziesz w drugim launcherze",
-    "grasscutter_elevation": "Sposób uruchomienia GC na ograniczonym porcie"
+    "grasscutter_elevation": "Sposób uruchomienia GC na ograniczonym porcie",
+    "web_cache": "Usuń folder webCaches",
+    "launch_args": "Launch Args"
   },
   "downloads": {
     "grasscutter_fullbuild": "Pobierz Grasscutter (wszystko w jednym)",

--- a/src-tauri/lang/pt-br.json
+++ b/src-tauri/lang/pt-br.json
@@ -33,7 +33,9 @@
     "horny_mode": "Modo com tesão",
     "auto_mongodb": "Iniciar MongoDB Automaticamente",
     "un_elevated": "Executar o jogo não-elevated (sem admin)",
-    "redirect_more": "Também redirecionar outros jogos MHY"
+    "redirect_more": "Também redirecionar outros jogos MHY",
+    "web_cache": "Excluir pasta webCaches",
+    "launch_args": "Launch Args"
   },
   "downloads": {
     "grasscutter_fullbuild": "Baixar o Grasscutter Tudo-em-Um",

--- a/src-tauri/lang/ru.json
+++ b/src-tauri/lang/ru.json
@@ -32,7 +32,9 @@
     "horny_mode": "роговой режим",
     "auto_mongodb": "Автоматически запускать MongoDB",
     "un_elevated": "Запустите игру в неэлегантном режиме (без администратора)",
-    "redirect_more": "Также перенаправьте другие игры MHY"
+    "redirect_more": "Также перенаправьте другие игры MHY",
+    "web_cache": "Удалить папку webCaches",
+    "launch_args": "Launch Args"
   },
   "downloads": {
     "grasscutter_fullbuild": "Скачать все в одном Grasscutter",

--- a/src-tauri/lang/vi.json
+++ b/src-tauri/lang/vi.json
@@ -33,7 +33,9 @@
     "horny_mode": "Chế độ hứng tình",
     "auto_mongodb": "Tự động khởi động MongoDB",
     "un_elevated": "Chạy trò chơi không nâng cao (không có quản trị viên)",
-    "redirect_more": "Đồng thời chuyển hướng các trò chơi MHY khác"
+    "redirect_more": "Đồng thời chuyển hướng các trò chơi MHY khác",
+    "web_cache": "Xóa thư mục webCaches",
+    "launch_args": "Launch Args"
   },
   "downloads": {
     "grasscutter_fullbuild": "Tải Grasscutter tất cả trong một",

--- a/src-tauri/src/system_helpers.rs
+++ b/src-tauri/src/system_helpers.rs
@@ -214,7 +214,7 @@ pub fn run_jar(path: String, execute_in: String, java_path: String) {
 
 #[cfg(not(target_os = "linux"))]
 #[tauri::command]
-pub fn run_jar_root(path: String, execute_in: String, java_path: String) {
+pub fn run_jar_root(_path: String, _execute_in: String, _java_path: String) {
   panic!("Not implemented");
 }
 

--- a/src/ui/components/ServerLaunchSection.tsx
+++ b/src/ui/components/ServerLaunchSection.tsx
@@ -41,6 +41,7 @@ interface IState {
   migotoSet: boolean
 
   unElevated: boolean
+  launchArgs: string
 }
 
 export default class ServerLaunchSection extends React.Component<IProps, IState> {
@@ -64,6 +65,7 @@ export default class ServerLaunchSection extends React.Component<IProps, IState>
       akebiSet: false,
       migotoSet: false,
       unElevated: false,
+      launchArgs: '',
     }
 
     this.toggleGrasscutter = this.toggleGrasscutter.bind(this)
@@ -95,6 +97,7 @@ export default class ServerLaunchSection extends React.Component<IProps, IState>
       akebiSet: config.akebi_path !== '',
       migotoSet: config.migoto_path !== '',
       unElevated: config.un_elevated || false,
+      launchArgs: config.launch_args || '',
     })
   }
 
@@ -214,9 +217,13 @@ export default class ServerLaunchSection extends React.Component<IProps, IState>
       if (config.un_elevated) {
         await invoke('run_un_elevated', {
           path: config.game_install_path,
+          args: config.launch_args,
         })
       } else {
-        await invoke('run_program_relative', { path: exe || config.game_install_path })
+        await invoke('run_program_relative', {
+          path: exe || config.game_install_path,
+          args: config.launch_args,
+        })
       }
     else alert('Game not found! At: ' + (exe || config.game_install_path))
   }

--- a/src/ui/components/ServerLaunchSection.tsx
+++ b/src/ui/components/ServerLaunchSection.tsx
@@ -41,7 +41,6 @@ interface IState {
   migotoSet: boolean
 
   unElevated: boolean
-  launchArgs: string
 }
 
 export default class ServerLaunchSection extends React.Component<IProps, IState> {
@@ -65,7 +64,6 @@ export default class ServerLaunchSection extends React.Component<IProps, IState>
       akebiSet: false,
       migotoSet: false,
       unElevated: false,
-      launchArgs: '',
     }
 
     this.toggleGrasscutter = this.toggleGrasscutter.bind(this)
@@ -97,7 +95,6 @@ export default class ServerLaunchSection extends React.Component<IProps, IState>
       akebiSet: config.akebi_path !== '',
       migotoSet: config.migoto_path !== '',
       unElevated: config.un_elevated || false,
-      launchArgs: config.launch_args || '',
     })
   }
 

--- a/src/ui/components/ServerLaunchSection.tsx
+++ b/src/ui/components/ServerLaunchSection.tsx
@@ -16,6 +16,7 @@ import { GrasscutterElevation } from './menu/Options'
 import { getGameExecutable, getGameVersion, getGrasscutterJar } from '../../utils/game'
 import { patchGame, unpatchGame } from '../../utils/rsa'
 import { listen } from '@tauri-apps/api/event'
+import { confirm } from '@tauri-apps/api/dialog'
 
 interface IProps {
   openExtras: (playGame: () => void) => void
@@ -116,6 +117,24 @@ export default class ServerLaunchSection extends React.Component<IProps, IState>
     if (!(await getGameExecutable())) {
       alert('Game executable not set!')
       return
+    }
+
+    // Check for HTTPS on local
+    if (this.state.httpsEnabled) {
+      if (this.state.ip == 'localhost') {
+        if (
+          await confirm(
+            "Oops! HTTPS is enabled but you're connecting to localhost! \nHTTPS MUST be disabled for localhost. \n\nWould you like to disable HTTPS and continue?",
+            { title: 'WARNING!!', type: 'warning' }
+          )
+        ) {
+          this.toggleHttps()
+        } else {
+          if (!(await confirm('You have chosen to keep HTTPS enabled! \n\nYOU WILL ERROR ON LOGIN.'))) {
+            return
+          }
+        }
+      }
     }
 
     // Connect to proxy

--- a/src/ui/components/menu/Options.tsx
+++ b/src/ui/components/menu/Options.tsx
@@ -706,7 +706,7 @@ export default class Options extends React.Component<IProps, IState> {
             key="launch_args"
             placeholder={'-arg=value'}
             onChange={this.setLaunchArgs}
-            initalValue={this.state.launch_args}
+            initalValue={this.state?.launch_args}
           />
         </div>
       </Menu>

--- a/src/ui/components/menu/Options.tsx
+++ b/src/ui/components/menu/Options.tsx
@@ -111,6 +111,8 @@ export default class Options extends React.Component<IProps, IState> {
     this.addMigotoDelay = this.addMigotoDelay.bind(this)
     this.toggleUnElevatedGame = this.toggleUnElevatedGame.bind(this)
     this.setLaunchArgs = this.setLaunchArgs.bind(this)
+
+    this.forceUpdate()
   }
 
   async componentDidMount() {
@@ -149,7 +151,7 @@ export default class Options extends React.Component<IProps, IState> {
       platform,
       un_elevated: config.un_elevated || false,
       redirect_more: config.redirect_more || false,
-      launch_args: config.launch_args || '',
+      launch_args: config.launch_args,
 
       // Linux stuff
       grasscutter_elevation: config.grasscutter_elevation || GrasscutterElevation.None,
@@ -706,7 +708,7 @@ export default class Options extends React.Component<IProps, IState> {
             key="launch_args"
             placeholder={'-arg=value'}
             onChange={this.setLaunchArgs}
-            initalValue={this.state?.launch_args}
+            value={this.state.launch_args}
           />
         </div>
       </Menu>

--- a/src/ui/components/menu/Options.tsx
+++ b/src/ui/components/menu/Options.tsx
@@ -17,6 +17,7 @@ import * as meta from '../../../utils/rsa'
 import HelpButton from '../common/HelpButton'
 import SmallButton from '../common/SmallButton'
 import { confirm } from '@tauri-apps/api/dialog'
+import TextInput from '../common/TextInput'
 
 export enum GrasscutterElevation {
   None = 'None',
@@ -50,6 +51,7 @@ interface IState {
   platform: string
   un_elevated: boolean
   redirect_more: boolean
+  launch_args: string
 
   // Linux stuff
   grasscutter_elevation: string
@@ -85,6 +87,7 @@ export default class Options extends React.Component<IProps, IState> {
       platform: '',
       un_elevated: false,
       redirect_more: false,
+      launch_args: '',
 
       // Linux stuff
       grasscutter_elevation: GrasscutterElevation.None,
@@ -107,6 +110,7 @@ export default class Options extends React.Component<IProps, IState> {
     this.deleteWebCache = this.deleteWebCache.bind(this)
     this.addMigotoDelay = this.addMigotoDelay.bind(this)
     this.toggleUnElevatedGame = this.toggleUnElevatedGame.bind(this)
+    this.setLaunchArgs = this.setLaunchArgs.bind(this)
   }
 
   async componentDidMount() {
@@ -145,6 +149,7 @@ export default class Options extends React.Component<IProps, IState> {
       platform,
       un_elevated: config.un_elevated || false,
       redirect_more: config.redirect_more || false,
+      launch_args: config.launch_args || '',
 
       // Linux stuff
       grasscutter_elevation: config.grasscutter_elevation || GrasscutterElevation.None,
@@ -371,6 +376,14 @@ export default class Options extends React.Component<IProps, IState> {
     // @ts-expect-error shut up bitch
     this.setState({
       [opt]: changedVal,
+    })
+  }
+
+  async setLaunchArgs(value: string) {
+    await setConfigOption('launch_args', value)
+
+    this.setState({
+      launch_args: value,
     })
   }
 
@@ -685,6 +698,16 @@ export default class Options extends React.Component<IProps, IState> {
               <Tr text="components.delete" />
             </BigButton>
           </div>
+          <div className="OptionLabel" id="menuOptionsLaunchArgs">
+            <Tr text="options.launch_args" />
+          </div>
+          <TextInput
+            id="launch_args"
+            key="launch_args"
+            placeholder={'-arg=value'}
+            onChange={this.setLaunchArgs}
+            initalValue={this.state.launch_args}
+          />
         </div>
       </Menu>
     )

--- a/src/ui/components/menu/Options.tsx
+++ b/src/ui/components/menu/Options.tsx
@@ -111,8 +111,6 @@ export default class Options extends React.Component<IProps, IState> {
     this.addMigotoDelay = this.addMigotoDelay.bind(this)
     this.toggleUnElevatedGame = this.toggleUnElevatedGame.bind(this)
     this.setLaunchArgs = this.setLaunchArgs.bind(this)
-
-    this.forceUpdate()
   }
 
   async componentDidMount() {

--- a/src/ui/components/menu/Options.tsx
+++ b/src/ui/components/menu/Options.tsx
@@ -103,6 +103,7 @@ export default class Options extends React.Component<IProps, IState> {
     this.setCustomBackground = this.setCustomBackground.bind(this)
     this.toggleEncryption = this.toggleEncryption.bind(this)
     this.removeRSA = this.removeRSA.bind(this)
+    this.deleteWebCache = this.deleteWebCache.bind(this)
     this.addMigotoDelay = this.addMigotoDelay.bind(this)
     this.toggleUnElevatedGame = this.toggleUnElevatedGame.bind(this)
   }
@@ -334,6 +335,18 @@ export default class Options extends React.Component<IProps, IState> {
     await invoke('generate_ca_files', {
       path: (await dataDir()) + 'cultivation',
     })
+  }
+
+  async deleteWebCache() {
+    alert('Cultivation may freeze for a moment while this occurs!')
+
+    // Get webCaches folder path
+    const pathArr = this.state.game_install_path.replace(/\\/g, '/').split('/')
+    pathArr.pop()
+    const path = pathArr.join('/') + '/GenshinImpact_Data/webCaches'
+
+    // Delete the folder
+    await invoke('dir_delete', { path: path })
   }
 
   async toggleOption(opt: keyof Configuration) {
@@ -644,6 +657,19 @@ export default class Options extends React.Component<IProps, IState> {
                 </option>
               ))}
             </select>
+          </div>
+        </div>
+
+        <Divider />
+
+        <div className="OptionSection" id="menuOptionsContainerAdvanced">
+          <div className="OptionLabel" id="menuOptionsLabelWebCache">
+            <Tr text="options.web_cache" />
+          </div>
+          <div className="OptionValue" id="menuOptionsButtondeleteWebcache">
+            <BigButton onClick={this.deleteWebCache} id="deleteWebcache">
+              <Tr text="components.delete" />
+            </BigButton>
           </div>
         </div>
       </Menu>

--- a/src/ui/components/menu/Options.tsx
+++ b/src/ui/components/menu/Options.tsx
@@ -344,9 +344,11 @@ export default class Options extends React.Component<IProps, IState> {
     const pathArr = this.state.game_install_path.replace(/\\/g, '/').split('/')
     pathArr.pop()
     const path = pathArr.join('/') + '/GenshinImpact_Data/webCaches'
+    const path2 = pathArr.join('/') + '/Yuanshen_Data/webCaches'
 
     // Delete the folder
     await invoke('dir_delete', { path: path })
+    await invoke('dir_delete', { path: path2 })
   }
 
   async toggleOption(opt: keyof Configuration) {

--- a/src/ui/components/menu/Options.tsx
+++ b/src/ui/components/menu/Options.tsx
@@ -16,6 +16,7 @@ import DownloadHandler from '../../../utils/download'
 import * as meta from '../../../utils/rsa'
 import HelpButton from '../common/HelpButton'
 import SmallButton from '../common/SmallButton'
+import { confirm } from '@tauri-apps/api/dialog'
 
 export enum GrasscutterElevation {
   None = 'None',
@@ -290,6 +291,17 @@ export default class Options extends React.Component<IProps, IState> {
     // Remove jar from path
     const path = config.grasscutter_path.replace(/\\/g, '/')
     const folderPath = path.substring(0, path.lastIndexOf('/'))
+
+    if (!(await server.encryptionEnabled(folderPath + '/config.json'))) {
+      if (
+        !(await confirm(
+          'Cultivation requires encryption DISABLED to connect and play locally. \n\n Are you sure you want to enable encryption?',
+          'Warning!'
+        ))
+      ) {
+        return
+      }
+    }
 
     await server.toggleEncryption(folderPath + '/config.json')
 

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -28,6 +28,7 @@ let defaultConfig: Configuration
     auto_mongodb: false,
     un_elevated: false,
     redirect_more: false,
+    launch_args: '',
 
     // Linux stuff
     grasscutter_elevation: 'None',
@@ -62,6 +63,7 @@ export interface Configuration {
   auto_mongodb: boolean
   un_elevated: boolean
   redirect_more: boolean
+  launch_args: string
 
   // Linux stuff
   grasscutter_elevation: string


### PR DESCRIPTION
Adds some new alerts for users trying to do things wrong and adds a couple of advanced user features in-menu.
- Launch args can be set from settings
- Web cache folder delete button added
- HTTPS check when launching to localhost, offering to disable it and warning them if they still say no
- Encryption check with warning when trying to enable it

Technically also solves #192 though it wasn't really needing fixing. This acts as the 'easy' method to accomplish that.