### PR TITLE
Bugfixes

### DIFF
--- a/src/ui/Main.tsx
+++ b/src/ui/Main.tsx
@@ -182,35 +182,33 @@ export class Main extends React.Component<IProps, IState> {
     // Update launch args to allow launching when updating from old versions
     await setConfigOption('launch_args', await getConfigOption('launch_args'))
 
-    if (!(await getConfigOption('offline_mode'))) {
-      // Get latest version and compare to this version
-      const latestVersion: {
-        tag_name: string
-        link: string
-      } = await invoke('get_latest_release')
-      const tagName = latestVersion?.tag_name.replace(/[^\d.]/g, '')
+    // Get latest version and compare to this version
+    const latestVersion: {
+      tag_name: string
+      link: string
+    } = await invoke('get_latest_release')
+    const tagName = latestVersion?.tag_name.replace(/[^\d.]/g, '')
 
-      // Check if tagName is different than current version
-      if (tagName && tagName !== (await getVersion())) {
-        // Display notification of new release
+    // Check if tagName is different than current version
+    if (tagName && tagName !== (await getVersion())) {
+      // Display notification of new release
+      this.setState({
+        notification: (
+          <>
+            Cultivation{' '}
+            <a href="#" onClick={() => invoke('open_in_browser', { url: latestVersion.link })}>
+              {latestVersion?.tag_name}
+            </a>{' '}
+            is now available!
+          </>
+        ),
+      })
+
+      setTimeout(() => {
         this.setState({
-          notification: (
-            <>
-              Cultivation{' '}
-              <a href="#" onClick={() => invoke('open_in_browser', { url: latestVersion.link })}>
-                {latestVersion?.tag_name}
-              </a>{' '}
-              is now available!
-            </>
-          ),
+          notification: null,
         })
-
-        setTimeout(() => {
-          this.setState({
-            notification: null,
-          })
-        }, 6000)
-      }
+      }, 6000)
     }
 
     // Period check to only show progress bar when downloading files

--- a/src/ui/Main.tsx
+++ b/src/ui/Main.tsx
@@ -179,33 +179,38 @@ export class Main extends React.Component<IProps, IState> {
     const updatedConfig = await getConfigOption('patch_rsa')
     await setConfigOption('patch_rsa', updatedConfig)
 
-    // Get latest version and compare to this version
-    const latestVersion: {
-      tag_name: string
-      link: string
-    } = await invoke('get_latest_release')
-    const tagName = latestVersion?.tag_name.replace(/[^\d.]/g, '')
+    // Update launch args to allow launching when updating from old versions
+    await setConfigOption('launch_args', await getConfigOption('launch_args'))
 
-    // Check if tagName is different than current version
-    if (tagName && tagName !== (await getVersion())) {
-      // Display notification of new release
-      this.setState({
-        notification: (
-          <>
-            Cultivation{' '}
-            <a href="#" onClick={() => invoke('open_in_browser', { url: latestVersion.link })}>
-              {latestVersion?.tag_name}
-            </a>{' '}
-            is now available!
-          </>
-        ),
-      })
+    if (!(await getConfigOption('offline_mode'))) {
+      // Get latest version and compare to this version
+      const latestVersion: {
+        tag_name: string
+        link: string
+      } = await invoke('get_latest_release')
+      const tagName = latestVersion?.tag_name.replace(/[^\d.]/g, '')
 
-      setTimeout(() => {
+      // Check if tagName is different than current version
+      if (tagName && tagName !== (await getVersion())) {
+        // Display notification of new release
         this.setState({
-          notification: null,
+          notification: (
+            <>
+              Cultivation{' '}
+              <a href="#" onClick={() => invoke('open_in_browser', { url: latestVersion.link })}>
+                {latestVersion?.tag_name}
+              </a>{' '}
+              is now available!
+            </>
+          ),
         })
-      }, 6000)
+
+        setTimeout(() => {
+          this.setState({
+            notification: null,
+          })
+        }, 6000)
+      }
     }
 
     // Period check to only show progress bar when downloading files

--- a/src/ui/Main.tsx
+++ b/src/ui/Main.tsx
@@ -154,6 +154,10 @@ export class Main extends React.Component<IProps, IState> {
       game_install_path: game_path,
     })
 
+    if (this.state.game_install_path === '') {
+      this.setState({ isGamePathSet: false })
+    }
+
     this.setState({
       migotoSet: !!(await getConfigOption('migoto_path')),
     })
@@ -329,7 +333,10 @@ export class Main extends React.Component<IProps, IState> {
           this.state.optionsOpen ? (
             <Options
               downloadManager={this.props.downloadHandler}
-              closeFn={() => this.setState({ optionsOpen: !this.state.optionsOpen })}
+              closeFn={async () => {
+                this.setState({ optionsOpen: !this.state.optionsOpen })
+                this.setState({ migotoSet: !!(await getConfigOption('migoto_path')) })
+              }}
             />
           ) : null
         }

--- a/src/ui/Main.tsx
+++ b/src/ui/Main.tsx
@@ -45,6 +45,7 @@ interface IState {
   notification: React.ReactElement | null
   isGamePathSet: boolean
   game_install_path: string
+  platform: string
 }
 
 export class Main extends React.Component<IProps, IState> {
@@ -64,6 +65,7 @@ export class Main extends React.Component<IProps, IState> {
       notification: null,
       isGamePathSet: true,
       game_install_path: '',
+      platform: '',
     }
 
     listen('lang_error', (payload) => {
@@ -156,6 +158,10 @@ export class Main extends React.Component<IProps, IState> {
       migotoSet: !!(await getConfigOption('migoto_path')),
     })
 
+    this.setState({
+      platform: await invoke('get_platform'),
+    })
+
     if (!cert_generated) {
       // Generate the certificate
       await invoke('generate_ca_files', {
@@ -222,7 +228,7 @@ export class Main extends React.Component<IProps, IState> {
     })) as boolean
 
     // Set no game path so the user understands it doesn't exist there
-    if (!game_exists) {
+    if (!game_exists && this.state.platform === 'windows') {
       setConfigOption('game_install_path', '')
     }
 


### PR DESCRIPTION
Fixes:
- Game failing to launch after updating from an old version of Cultivation
- Mods menu wrench not appearing unless the app was reloaded - now loads when the user closes options
- Linux builds erroneously always removing the game path when it was set
- "Game not set" warning not appearing after restarting Cultivation