### PR TITLE
Update launch_args, Fix login timeout and transparency support

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -67,6 +67,7 @@
     "windows": [
       {
         "fullscreen": false,
+        "transparent": true,
         "height": 730,
         "resizable": true,
         "title": "Cultivation",

--- a/src/ui/components/menu/Options.tsx
+++ b/src/ui/components/menu/Options.tsx
@@ -823,25 +823,32 @@ export default class Options extends React.Component<IProps, IState> {
               <Tr text="components.delete" />
             </BigButton>
           </div>
+        </div>
+
+        <div className="OptionSection" id="menuOptionsContainerLaunchArgs">
           <div className="OptionLabel" id="menuOptionsLaunchArgs">
             <Tr text="options.launch_args" />
           </div>
-          <TextInput
-            id="launch_args"
-            key="launch_args"
-            placeholder={'-arg=value'}
-            onChange={this.setLaunchArgs}
-            value={this.state.launch_args}
-          />
+          <div className="OptionValue" id="menuOptionsValueLaunchArgs">
+            <TextInput
+              id="launch_args"
+              key="launch_args"
+              placeholder={'-arg=value'}
+              onChange={this.setLaunchArgs}
+              value={this.state.launch_args}
+            />
+          </div>
         </div>
 
-        <div className="OptionLabel" id="menuOptionsLabelFixRes">
-          <Tr text="options.fix_res" />
-        </div>
-        <div className="OptionValue" id="menuOptionsButtonfixRes">
-          <BigButton onClick={this.fixRes} id="fixRes">
-            <Tr text="components.fix" />
-          </BigButton>
+        <div className="OptionSection" id="menuOptionsContainerFixRes">
+          <div className="OptionLabel" id="menuOptionsLabelFixRes">
+            <Tr text="options.fix_res" />
+          </div>
+          <div className="OptionValue" id="menuOptionsButtonfixRes">
+            <BigButton onClick={this.fixRes} id="fixRes">
+              <Tr text="components.fix" />
+            </BigButton>
+          </div>
         </div>
       </Menu>
     )


### PR DESCRIPTION
Firstly, thank you so much for creating this amazing application it makes launching some PS much easier. 

So, when I was working on the latest Hoyoplay theme port, I ran into a roadblock with the end of the options section because the launch_args and Fix login timeout don't use their own OptionSection container. So, I made this pull request to help our community members who also create themes, making it easier for them to develop their themes. 

Current:
![image](https://github.com/user-attachments/assets/7082b779-9522-4f15-9ae9-6759c254ec2e)

Which make the inconsistency look:
![image](https://github.com/user-attachments/assets/6b9e42fe-0e2a-4d3a-a2b6-6fa56824ffd6)

So, I make some change to make it look more consistent:
![image](https://github.com/user-attachments/assets/d91e05a9-7c11-478c-9c10-110297f60b70)

Which also make the theming easier:
![image](https://github.com/user-attachments/assets/3db649a5-a20a-479e-abff-5286779d3836)


For transparency, it resolves the white leftover issue that occurs when creating rounded corners for windows, which is not currently supported.
Current:
![Screenshot 2025-07-01 194725](https://github.com/user-attachments/assets/cc87d192-52ae-49f3-97c8-1c10ce704514)

Fixed:
![image](https://github.com/user-attachments/assets/7b0ea3c4-82e7-4e8f-90f4-ec749207995b)

Note: **_The theme shown was for example purpose only which is still WIP stage. and not included on PR_**

Please review and test the pull request, as it could be very useful for theming purposes and does not affect critical functionality. Thank you!